### PR TITLE
LockManagerElement by Element Name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+﻿root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+end_of_line = crlf
+trim_trailing_whitespace = true
+
+[*.cs]
+dotnet_sort_system_directives_first = true

--- a/LockManager/LockManagerElement.cs
+++ b/LockManager/LockManagerElement.cs
@@ -1,192 +1,217 @@
 ﻿namespace Skyline.DataMiner.ConnectorAPI.SkylineLockManager.LockManager
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Diagnostics;
-	using System.Linq;
-	using Newtonsoft.Json;
-	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager;
-	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages;
-	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Locking;
-	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Unlocking;
-	using Skyline.DataMiner.Core.DataMinerSystem.Common;
-	using Skyline.DataMiner.Core.InterAppCalls.Common.CallBulk;
-	using Skyline.DataMiner.Core.InterAppCalls.Common.CallSingle;
-	using Skyline.DataMiner.Net;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using Newtonsoft.Json;
+    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager;
+    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages;
+    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Locking;
+    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Unlocking;
+    using Skyline.DataMiner.Core.DataMinerSystem.Common;
+    using Skyline.DataMiner.Core.InterAppCalls.Common.CallBulk;
+    using Skyline.DataMiner.Core.InterAppCalls.Common.CallSingle;
+    using Skyline.DataMiner.Net;
 
-	/// <inheritdoc cref="ILockManagerElement"/>
-	public class LockManagerElement : ILockManagerElement
-	{
-		private static readonly int InterAppReceive_ParameterId = 9000000;
-		private static readonly int InterAppTimeout_ParameterId = 100;
+    /// <inheritdoc cref="ILockManagerElement"/>
+    public class LockManagerElement : ILockManagerElement
+    {
+        private static readonly int InterAppReceive_ParameterId = 9000000;
+        private static readonly int InterAppTimeout_ParameterId = 100;
 
-		private readonly IConnection connection;
-		private readonly IDmsElement element;
-		private readonly ILogger logger;
+        private readonly IConnection connection;
+        private readonly IDmsElement element;
+        private readonly ILogger logger;
 
-		private readonly Lazy<TimeSpan> timeout;
+        private readonly Lazy<TimeSpan> timeout;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="LockManagerElement"/> class.
-		/// </summary>
-		/// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
-		/// <param name="agentId">ID of the agent on which the Lock Manager element is hosted.</param>
-		/// <param name="elementId">ID of the Lock Manager element.</param>
-		/// <param name="logger">Object that is used to log info about locks.</param>
-		/// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
-		/// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
-		/// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
-		public LockManagerElement(IConnection connection, int agentId, int elementId, ILogger logger = null)
-		{
-			this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
-			this.logger = logger;
-			this.timeout = new Lazy<TimeSpan>(GetTimeout);
+        /// <summary>
+        /// Name of the Connector with which this element is able to communicate.
+        /// </summary>
+        public static readonly string SkylineLockManager_ConnectorName = "Skyline Lock Manager";
 
-			element = connection.GetDms().GetElement(new DmsElementId(agentId, elementId)) ?? throw new ArgumentException($"Unable to find an element with ID {agentId}\\{elementId}", nameof(elementId));
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockManagerElement"/> class.
+        /// </summary>
+        /// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
+        /// <param name="agentId">ID of the agent on which the Lock Manager element is hosted.</param>
+        /// <param name="elementId">ID of the Lock Manager element.</param>
+        /// <param name="logger">Object that is used to log info about locks.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
+        public LockManagerElement(IConnection connection, int agentId, int elementId, ILogger logger = null)
+        {
+            this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            this.logger = logger;
+            this.timeout = new Lazy<TimeSpan>(GetTimeout);
 
-			if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
-		}
+            element = connection.GetDms().GetElement(new DmsElementId(agentId, elementId)) ?? throw new ArgumentException($"Unable to find an element with ID {agentId}\\{elementId}", nameof(elementId));
 
-		private TimeSpan Timeout => timeout.Value;
+            if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
+        }
 
-		/// <summary>
-		/// A collection containing all classes used in InterApp communication.
-		/// </summary>
-		public static IReadOnlyCollection<Type> InterAppKnownTypes { get; } = new List<Type>
-		{
-			typeof(IInterAppCall),
-			typeof(LockObjectsRequestsMessage),
-			typeof(LockObjectsResponsesMessage),
-			typeof(UnlockObjectsRequestsMessage),
-			typeof(FailureMessage),
-		};
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockManagerElement"/> class.
+        /// </summary>
+        /// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
+        /// <param name="elementName">Name of the Lock Manager element.</param>
+        /// <param name="logger">Object that is used to log info about locks.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
+        public LockManagerElement(IConnection connection, string elementName, ILogger logger = null)
+        {
+            this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            this.logger = logger;
+            this.timeout = new Lazy<TimeSpan>(GetTimeout);
 
-		/// <inheritdoc cref="ILockManagerElement.LockObject(LockObjectRequest)"/>
-		/// <exception cref="ArgumentNullException"/>
-		/// <exception cref="InvalidOperationException"/>
-		public ILockInfo LockObject(LockObjectRequest request)
-		{
-			return LockObjects(new[] { request }).Single();
-		}
+            element = connection.GetDms().GetElement(elementName) ?? throw new ArgumentException($"Unable to find an element with Name {elementName}", nameof(elementName));
 
-		/// <inheritdoc cref="ILockManagerElement.LockObjects(IEnumerable{LockObjectRequest})"/>
-		/// <exception cref="ArgumentNullException"/>
-		/// <exception cref="InvalidOperationException"/>
-		public IEnumerable<ILockInfo> LockObjects(IEnumerable<LockObjectRequest> requests)
-		{
-			if (requests is null) throw new ArgumentNullException(nameof(requests));
+            if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
+        }
 
-			var requestsList = requests.ToList();
+        private TimeSpan Timeout => timeout.Value;
 
-			if (!requestsList.Any()) return Enumerable.Empty<ILockInfo>();
+        /// <summary>
+        /// A collection containing all classes used in InterApp communication.
+        /// </summary>
+        public static IReadOnlyCollection<Type> InterAppKnownTypes { get; } = new List<Type>
+        {
+            typeof(IInterAppCall),
+            typeof(LockObjectsRequestsMessage),
+            typeof(LockObjectsResponsesMessage),
+            typeof(UnlockObjectsRequestsMessage),
+            typeof(FailureMessage),
+        };
 
-			var lockObjectsRequestsMessage = new LockObjectsRequestsMessage
-			{
-				Requests = requestsList,
-			};
+        /// <inheritdoc cref="ILockManagerElement.LockObject(LockObjectRequest)"/>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="InvalidOperationException"/>
+        public ILockInfo LockObject(LockObjectRequest request)
+        {
+            return LockObjects(new[] { request }).Single();
+        }
 
-			Log($"Requesting locks for {string.Join(", ", requestsList)}");
+        /// <inheritdoc cref="ILockManagerElement.LockObjects(IEnumerable{LockObjectRequest})"/>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="InvalidOperationException"/>
+        public IEnumerable<ILockInfo> LockObjects(IEnumerable<LockObjectRequest> requests)
+        {
+            if (requests is null) throw new ArgumentNullException(nameof(requests));
 
-			SendMessageWithResponse(lockObjectsRequestsMessage, out LockObjectsResponsesMessage responseMessage);
+            var requestsList = requests.ToList();
 
-			return responseMessage.Responses.Select(x => new LockInfo
-			{
-				LockHolderInfo = x.LockHolderInfo,
-				IsGranted = x.LockIsGranted,
-				ObjectId = x.ObjectId,
-				AutoUnlockTimestamp = x.AutoUnlockTimestamp,
-			}).ToList();
-		}
+            if (!requestsList.Any()) return Enumerable.Empty<ILockInfo>();
 
-		/// <inheritdoc cref="ILockManagerElement.UnlockObject(UnlockObjectRequest)"/>
-		/// <exception cref="ArgumentNullException"/>
-		public void UnlockObject(UnlockObjectRequest request)
-		{
-			UnlockObjects(new[] { request });
-		}
+            var lockObjectsRequestsMessage = new LockObjectsRequestsMessage
+            {
+                Requests = requestsList,
+            };
 
-		/// <inheritdoc cref="ILockManagerElement.UnlockObjects(IEnumerable{UnlockObjectRequest})"/>
-		/// <exception cref="ArgumentNullException"/>
-		public void UnlockObjects(IEnumerable<UnlockObjectRequest> requests)
-		{
-			if (requests is null) throw new ArgumentNullException(nameof(requests));
+            Log($"Requesting locks for {string.Join(", ", requestsList)}");
 
-			var requestsList = requests.ToList();
+            SendMessageWithResponse(lockObjectsRequestsMessage, out LockObjectsResponsesMessage responseMessage);
 
-			if (!requestsList.Any()) return;
+            return responseMessage.Responses.Select(x => new LockInfo
+            {
+                LockHolderInfo = x.LockHolderInfo,
+                IsGranted = x.LockIsGranted,
+                ObjectId = x.ObjectId,
+                AutoUnlockTimestamp = x.AutoUnlockTimestamp,
+            }).ToList();
+        }
 
-			var message = new UnlockObjectsRequestsMessage
-			{
-				Requests = requestsList,
-			};
+        /// <inheritdoc cref="ILockManagerElement.UnlockObject(UnlockObjectRequest)"/>
+        /// <exception cref="ArgumentNullException"/>
+        public void UnlockObject(UnlockObjectRequest request)
+        {
+            UnlockObjects(new[] { request });
+        }
 
-			SendMessageWithoutResponse(message);
+        /// <inheritdoc cref="ILockManagerElement.UnlockObjects(IEnumerable{UnlockObjectRequest})"/>
+        /// <exception cref="ArgumentNullException"/>
+        public void UnlockObjects(IEnumerable<UnlockObjectRequest> requests)
+        {
+            if (requests is null) throw new ArgumentNullException(nameof(requests));
 
-			Log($"Releasing locks for {string.Join(", ", requestsList)}");
-		}
+            var requestsList = requests.ToList();
 
-		private void SendMessageWithoutResponse(Message message)
-		{
-			var commands = InterAppCallFactory.CreateNew();
-			commands.Messages.Add(message);
+            if (!requestsList.Any()) return;
 
-			commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, InterAppKnownTypes);
-		}
+            var message = new UnlockObjectsRequestsMessage
+            {
+                Requests = requestsList,
+            };
 
-		private void SendMessageWithResponse<T>(Message message, out T responseMessage) where T : Message
-		{
-			responseMessage = default;
+            SendMessageWithoutResponse(message);
 
-			var commands = InterAppCallFactory.CreateNew();
-			commands.Messages.Add(message);
+            Log($"Releasing locks for {string.Join(", ", requestsList)}");
+        }
 
-			Log($"Message: {JsonConvert.SerializeObject(message)}");
+        private void SendMessageWithoutResponse(Message message)
+        {
+            var commands = InterAppCallFactory.CreateNew();
+            commands.Messages.Add(message);
 
-			var response = commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, Timeout, InterAppKnownTypes).First();
+            commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, InterAppKnownTypes);
+        }
 
-			Log($"Response: {JsonConvert.SerializeObject(response)}");
+        private void SendMessageWithResponse<T>(Message message, out T responseMessage) where T : Message
+        {
+            responseMessage = default;
 
-			if (response is FailureMessage failureResponse)
-			{
-				throw new InvalidOperationException(failureResponse.Message);
-			}
-			else if (response is T expectedResponse)
-			{
-				responseMessage = expectedResponse;
-			}
-			else
-			{
-				throw new InvalidOperationException($"Received response is not of type {typeof(T)}");
-			}	
-		}
+            var commands = InterAppCallFactory.CreateNew();
+            commands.Messages.Add(message);
 
-		private TimeSpan GetTimeout()
-		{
-			try
-			{
-				var timeoutInSeconds = element.GetStandaloneParameter<double?>(InterAppTimeout_ParameterId) ?? throw new ParameterNotFoundException($"Unable to find parameter {InterAppTimeout_ParameterId} in element {element.Name} ({element.DmsElementId})");
+            Log($"Message: {JsonConvert.SerializeObject(message)}");
 
-				var retrievedTimeout = TimeSpan.FromSeconds(timeoutInSeconds.GetValue().Value);
+            var response = commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, Timeout, InterAppKnownTypes).First();
 
-				Log($"Timeout: {timeout}");
+            Log($"Response: {JsonConvert.SerializeObject(response)}");
 
-				return retrievedTimeout;
-			}
-			catch (Exception e)
-			{
-				var retrievedTimeout = TimeSpan.FromSeconds(30);
+            if (response is FailureMessage failureResponse)
+            {
+                throw new InvalidOperationException(failureResponse.Message);
+            }
+            else if (response is T expectedResponse)
+            {
+                responseMessage = expectedResponse;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Received response is not of type {typeof(T)}");
+            }
+        }
 
-				Log($"Unable to retrieve timeout due to: {e}");
+        private TimeSpan GetTimeout()
+        {
+            try
+            {
+                var timeoutInSeconds = element.GetStandaloneParameter<double?>(InterAppTimeout_ParameterId) ?? throw new ParameterNotFoundException($"Unable to find parameter {InterAppTimeout_ParameterId} in element {element.Name} ({element.DmsElementId})");
 
-				return retrievedTimeout;
-			}
-		}
+                var retrievedTimeout = TimeSpan.FromSeconds(timeoutInSeconds.GetValue().Value);
 
-		private void Log(string message)
-		{
-			string nameOfMethod = new StackTrace().GetFrame(1).GetMethod().Name;
+                Log($"Timeout: {timeout}");
 
-			logger?.Log(nameof(LockManagerElement), nameOfMethod, message);
-		}
-	}
+                return retrievedTimeout;
+            }
+            catch (Exception e)
+            {
+                var retrievedTimeout = TimeSpan.FromSeconds(30);
+
+                Log($"Unable to retrieve timeout due to: {e}");
+
+                return retrievedTimeout;
+            }
+        }
+
+        private void Log(string message)
+        {
+            string nameOfMethod = new StackTrace().GetFrame(1).GetMethod().Name;
+
+            logger?.Log(nameof(LockManagerElement), nameOfMethod, message);
+        }
+    }
 }

--- a/LockManager/LockManagerElement.cs
+++ b/LockManager/LockManagerElement.cs
@@ -1,217 +1,217 @@
 ﻿namespace Skyline.DataMiner.ConnectorAPI.SkylineLockManager.LockManager
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using Newtonsoft.Json;
-    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager;
-    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages;
-    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Locking;
-    using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Unlocking;
-    using Skyline.DataMiner.Core.DataMinerSystem.Common;
-    using Skyline.DataMiner.Core.InterAppCalls.Common.CallBulk;
-    using Skyline.DataMiner.Core.InterAppCalls.Common.CallSingle;
-    using Skyline.DataMiner.Net;
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.Linq;
+	using Newtonsoft.Json;
+	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager;
+	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages;
+	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Locking;
+	using Skyline.DataMiner.ConnectorAPI.SkylineLockManager.Messages.Unlocking;
+	using Skyline.DataMiner.Core.DataMinerSystem.Common;
+	using Skyline.DataMiner.Core.InterAppCalls.Common.CallBulk;
+	using Skyline.DataMiner.Core.InterAppCalls.Common.CallSingle;
+	using Skyline.DataMiner.Net;
 
-    /// <inheritdoc cref="ILockManagerElement"/>
-    public class LockManagerElement : ILockManagerElement
-    {
-        private static readonly int InterAppReceive_ParameterId = 9000000;
-        private static readonly int InterAppTimeout_ParameterId = 100;
+	/// <inheritdoc cref="ILockManagerElement"/>
+	public class LockManagerElement : ILockManagerElement
+	{
+		private static readonly int InterAppReceive_ParameterId = 9000000;
+		private static readonly int InterAppTimeout_ParameterId = 100;
 
-        private readonly IConnection connection;
-        private readonly IDmsElement element;
-        private readonly ILogger logger;
+		private readonly IConnection connection;
+		private readonly IDmsElement element;
+		private readonly ILogger logger;
 
-        private readonly Lazy<TimeSpan> timeout;
+		private readonly Lazy<TimeSpan> timeout;
 
-        /// <summary>
-        /// Name of the Connector with which this element is able to communicate.
-        /// </summary>
-        public static readonly string SkylineLockManager_ConnectorName = "Skyline Lock Manager";
+		/// <summary>
+		/// Name of the Connector with which this element is able to communicate.
+		/// </summary>
+		public static readonly string SkylineLockManager_ConnectorName = "Skyline Lock Manager";
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LockManagerElement"/> class.
-        /// </summary>
-        /// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
-        /// <param name="agentId">ID of the agent on which the Lock Manager element is hosted.</param>
-        /// <param name="elementId">ID of the Lock Manager element.</param>
-        /// <param name="logger">Object that is used to log info about locks.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
-        public LockManagerElement(IConnection connection, int agentId, int elementId, ILogger logger = null)
-        {
-            this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
-            this.logger = logger;
-            this.timeout = new Lazy<TimeSpan>(GetTimeout);
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LockManagerElement"/> class.
+		/// </summary>
+		/// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
+		/// <param name="agentId">ID of the agent on which the Lock Manager element is hosted.</param>
+		/// <param name="elementId">ID of the Lock Manager element.</param>
+		/// <param name="logger">Object that is used to log info about locks.</param>
+		/// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
+		/// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
+		public LockManagerElement(IConnection connection, int agentId, int elementId, ILogger logger = null)
+		{
+			this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
+			this.logger = logger;
+			this.timeout = new Lazy<TimeSpan>(GetTimeout);
 
-            element = connection.GetDms().GetElement(new DmsElementId(agentId, elementId)) ?? throw new ArgumentException($"Unable to find an element with ID {agentId}\\{elementId}", nameof(elementId));
+			element = connection.GetDms().GetElement(new DmsElementId(agentId, elementId)) ?? throw new ArgumentException($"Unable to find an element with ID {agentId}\\{elementId}", nameof(elementId));
 
-            if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
-        }
+			if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LockManagerElement"/> class.
-        /// </summary>
-        /// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
-        /// <param name="elementName">Name of the Lock Manager element.</param>
-        /// <param name="logger">Object that is used to log info about locks.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
-        public LockManagerElement(IConnection connection, string elementName, ILogger logger = null)
-        {
-            this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
-            this.logger = logger;
-            this.timeout = new Lazy<TimeSpan>(GetTimeout);
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LockManagerElement"/> class.
+		/// </summary>
+		/// <param name="connection">Connection used to communicate with the Lock Manager element.</param>
+		/// <param name="elementName">Name of the Lock Manager element.</param>
+		/// <param name="logger">Object that is used to log info about locks.</param>
+		/// <exception cref="ArgumentNullException">Thrown when the provided connection or the element is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown when provided element id or agent id is negative.</exception>
+		/// <exception cref="InvalidOperationException">Thrown when described element is inactive.</exception>
+		public LockManagerElement(IConnection connection, string elementName, ILogger logger = null)
+		{
+			this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
+			this.logger = logger;
+			this.timeout = new Lazy<TimeSpan>(GetTimeout);
 
-            element = connection.GetDms().GetElement(elementName) ?? throw new ArgumentException($"Unable to find an element with Name {elementName}", nameof(elementName));
+			element = connection.GetDms().GetElement(elementName) ?? throw new ArgumentException($"Unable to find an element with Name {elementName}", nameof(elementName));
 
-            if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
-        }
+			if (element.State != ElementState.Active) throw new InvalidOperationException($"Element {element.Name} is not active");
+		}
 
-        private TimeSpan Timeout => timeout.Value;
+		private TimeSpan Timeout => timeout.Value;
 
-        /// <summary>
-        /// A collection containing all classes used in InterApp communication.
-        /// </summary>
-        public static IReadOnlyCollection<Type> InterAppKnownTypes { get; } = new List<Type>
-        {
-            typeof(IInterAppCall),
-            typeof(LockObjectsRequestsMessage),
-            typeof(LockObjectsResponsesMessage),
-            typeof(UnlockObjectsRequestsMessage),
-            typeof(FailureMessage),
-        };
+		/// <summary>
+		/// A collection containing all classes used in InterApp communication.
+		/// </summary>
+		public static IReadOnlyCollection<Type> InterAppKnownTypes { get; } = new List<Type>
+		{
+			typeof(IInterAppCall),
+			typeof(LockObjectsRequestsMessage),
+			typeof(LockObjectsResponsesMessage),
+			typeof(UnlockObjectsRequestsMessage),
+			typeof(FailureMessage),
+		};
 
-        /// <inheritdoc cref="ILockManagerElement.LockObject(LockObjectRequest)"/>
-        /// <exception cref="ArgumentNullException"/>
-        /// <exception cref="InvalidOperationException"/>
-        public ILockInfo LockObject(LockObjectRequest request)
-        {
-            return LockObjects(new[] { request }).Single();
-        }
+		/// <inheritdoc cref="ILockManagerElement.LockObject(LockObjectRequest)"/>
+		/// <exception cref="ArgumentNullException"/>
+		/// <exception cref="InvalidOperationException"/>
+		public ILockInfo LockObject(LockObjectRequest request)
+		{
+			return LockObjects(new[] { request }).Single();
+		}
 
-        /// <inheritdoc cref="ILockManagerElement.LockObjects(IEnumerable{LockObjectRequest})"/>
-        /// <exception cref="ArgumentNullException"/>
-        /// <exception cref="InvalidOperationException"/>
-        public IEnumerable<ILockInfo> LockObjects(IEnumerable<LockObjectRequest> requests)
-        {
-            if (requests is null) throw new ArgumentNullException(nameof(requests));
+		/// <inheritdoc cref="ILockManagerElement.LockObjects(IEnumerable{LockObjectRequest})"/>
+		/// <exception cref="ArgumentNullException"/>
+		/// <exception cref="InvalidOperationException"/>
+		public IEnumerable<ILockInfo> LockObjects(IEnumerable<LockObjectRequest> requests)
+		{
+			if (requests is null) throw new ArgumentNullException(nameof(requests));
 
-            var requestsList = requests.ToList();
+			var requestsList = requests.ToList();
 
-            if (!requestsList.Any()) return Enumerable.Empty<ILockInfo>();
+			if (!requestsList.Any()) return Enumerable.Empty<ILockInfo>();
 
-            var lockObjectsRequestsMessage = new LockObjectsRequestsMessage
-            {
-                Requests = requestsList,
-            };
+			var lockObjectsRequestsMessage = new LockObjectsRequestsMessage
+			{
+				Requests = requestsList,
+			};
 
-            Log($"Requesting locks for {string.Join(", ", requestsList)}");
+			Log($"Requesting locks for {string.Join(", ", requestsList)}");
 
-            SendMessageWithResponse(lockObjectsRequestsMessage, out LockObjectsResponsesMessage responseMessage);
+			SendMessageWithResponse(lockObjectsRequestsMessage, out LockObjectsResponsesMessage responseMessage);
 
-            return responseMessage.Responses.Select(x => new LockInfo
-            {
-                LockHolderInfo = x.LockHolderInfo,
-                IsGranted = x.LockIsGranted,
-                ObjectId = x.ObjectId,
-                AutoUnlockTimestamp = x.AutoUnlockTimestamp,
-            }).ToList();
-        }
+			return responseMessage.Responses.Select(x => new LockInfo
+			{
+				LockHolderInfo = x.LockHolderInfo,
+				IsGranted = x.LockIsGranted,
+				ObjectId = x.ObjectId,
+				AutoUnlockTimestamp = x.AutoUnlockTimestamp,
+			}).ToList();
+		}
 
-        /// <inheritdoc cref="ILockManagerElement.UnlockObject(UnlockObjectRequest)"/>
-        /// <exception cref="ArgumentNullException"/>
-        public void UnlockObject(UnlockObjectRequest request)
-        {
-            UnlockObjects(new[] { request });
-        }
+		/// <inheritdoc cref="ILockManagerElement.UnlockObject(UnlockObjectRequest)"/>
+		/// <exception cref="ArgumentNullException"/>
+		public void UnlockObject(UnlockObjectRequest request)
+		{
+			UnlockObjects(new[] { request });
+		}
 
-        /// <inheritdoc cref="ILockManagerElement.UnlockObjects(IEnumerable{UnlockObjectRequest})"/>
-        /// <exception cref="ArgumentNullException"/>
-        public void UnlockObjects(IEnumerable<UnlockObjectRequest> requests)
-        {
-            if (requests is null) throw new ArgumentNullException(nameof(requests));
+		/// <inheritdoc cref="ILockManagerElement.UnlockObjects(IEnumerable{UnlockObjectRequest})"/>
+		/// <exception cref="ArgumentNullException"/>
+		public void UnlockObjects(IEnumerable<UnlockObjectRequest> requests)
+		{
+			if (requests is null) throw new ArgumentNullException(nameof(requests));
 
-            var requestsList = requests.ToList();
+			var requestsList = requests.ToList();
 
-            if (!requestsList.Any()) return;
+			if (!requestsList.Any()) return;
 
-            var message = new UnlockObjectsRequestsMessage
-            {
-                Requests = requestsList,
-            };
+			var message = new UnlockObjectsRequestsMessage
+			{
+				Requests = requestsList,
+			};
 
-            SendMessageWithoutResponse(message);
+			SendMessageWithoutResponse(message);
 
-            Log($"Releasing locks for {string.Join(", ", requestsList)}");
-        }
+			Log($"Releasing locks for {string.Join(", ", requestsList)}");
+		}
 
-        private void SendMessageWithoutResponse(Message message)
-        {
-            var commands = InterAppCallFactory.CreateNew();
-            commands.Messages.Add(message);
+		private void SendMessageWithoutResponse(Message message)
+		{
+			var commands = InterAppCallFactory.CreateNew();
+			commands.Messages.Add(message);
 
-            commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, InterAppKnownTypes);
-        }
+			commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, InterAppKnownTypes);
+		}
 
-        private void SendMessageWithResponse<T>(Message message, out T responseMessage) where T : Message
-        {
-            responseMessage = default;
+		private void SendMessageWithResponse<T>(Message message, out T responseMessage) where T : Message
+		{
+			responseMessage = default;
 
-            var commands = InterAppCallFactory.CreateNew();
-            commands.Messages.Add(message);
+			var commands = InterAppCallFactory.CreateNew();
+			commands.Messages.Add(message);
 
-            Log($"Message: {JsonConvert.SerializeObject(message)}");
+			Log($"Message: {JsonConvert.SerializeObject(message)}");
 
-            var response = commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, Timeout, InterAppKnownTypes).First();
+			var response = commands.Send(connection, element.AgentId, element.Id, InterAppReceive_ParameterId, Timeout, InterAppKnownTypes).First();
 
-            Log($"Response: {JsonConvert.SerializeObject(response)}");
+			Log($"Response: {JsonConvert.SerializeObject(response)}");
 
-            if (response is FailureMessage failureResponse)
-            {
-                throw new InvalidOperationException(failureResponse.Message);
-            }
-            else if (response is T expectedResponse)
-            {
-                responseMessage = expectedResponse;
-            }
-            else
-            {
-                throw new InvalidOperationException($"Received response is not of type {typeof(T)}");
-            }
-        }
+			if (response is FailureMessage failureResponse)
+			{
+				throw new InvalidOperationException(failureResponse.Message);
+			}
+			else if (response is T expectedResponse)
+			{
+				responseMessage = expectedResponse;
+			}
+			else
+			{
+				throw new InvalidOperationException($"Received response is not of type {typeof(T)}");
+			}
+		}
 
-        private TimeSpan GetTimeout()
-        {
-            try
-            {
-                var timeoutInSeconds = element.GetStandaloneParameter<double?>(InterAppTimeout_ParameterId) ?? throw new ParameterNotFoundException($"Unable to find parameter {InterAppTimeout_ParameterId} in element {element.Name} ({element.DmsElementId})");
+		private TimeSpan GetTimeout()
+		{
+			try
+			{
+				var timeoutInSeconds = element.GetStandaloneParameter<double?>(InterAppTimeout_ParameterId) ?? throw new ParameterNotFoundException($"Unable to find parameter {InterAppTimeout_ParameterId} in element {element.Name} ({element.DmsElementId})");
 
-                var retrievedTimeout = TimeSpan.FromSeconds(timeoutInSeconds.GetValue().Value);
+				var retrievedTimeout = TimeSpan.FromSeconds(timeoutInSeconds.GetValue().Value);
 
-                Log($"Timeout: {timeout}");
+				Log($"Timeout: {timeout}");
 
-                return retrievedTimeout;
-            }
-            catch (Exception e)
-            {
-                var retrievedTimeout = TimeSpan.FromSeconds(30);
+				return retrievedTimeout;
+			}
+			catch (Exception e)
+			{
+				var retrievedTimeout = TimeSpan.FromSeconds(30);
 
-                Log($"Unable to retrieve timeout due to: {e}");
+				Log($"Unable to retrieve timeout due to: {e}");
 
-                return retrievedTimeout;
-            }
-        }
+				return retrievedTimeout;
+			}
+		}
 
-        private void Log(string message)
-        {
-            string nameOfMethod = new StackTrace().GetFrame(1).GetMethod().Name;
+		private void Log(string message)
+		{
+			string nameOfMethod = new StackTrace().GetFrame(1).GetMethod().Name;
 
-            logger?.Log(nameof(LockManagerElement), nameOfMethod, message);
-        }
-    }
+			logger?.Log(nameof(LockManagerElement), nameOfMethod, message);
+		}
+	}
 }


### PR DESCRIPTION
Added an overload constuctor to initialize the LockManagerElement based on element name. Else we would need a DMS call on our end to retrieve the element by name, only to pass the element and agent ID to the LockManagerElement on which you'll then again make a similar call to retrieve element instance.