### PR TITLE
Add return message for when the message broker is not available

### DIFF
--- a/ConnectorAPI.SkylineLockManager/ConnectorApi/InterAppHandler.cs
+++ b/ConnectorAPI.SkylineLockManager/ConnectorApi/InterAppHandler.cs
@@ -10,12 +10,14 @@
 	using Skyline.DataMiner.Core.DataMinerSystem.Common;
 	using Skyline.DataMiner.Core.InterAppCalls.Common.CallBulk;
 	using Skyline.DataMiner.Core.InterAppCalls.Common.CallSingle;
+	using Skyline.DataMiner.Core.InterAppCalls.Common.Shared;
 	using Skyline.DataMiner.Net;
 
 	internal class InterAppHandler : IInterAppHandler
 	{
 		private static readonly int InterAppTimeout_ParameterId = 100;
 		private static readonly int InterAppReceive_ParameterId = 9000000;
+		private static readonly int InterAppResponse_ParameterId = 9000001;
 
 		private readonly IConnection connection;
 		private readonly IDmsElement element;
@@ -69,6 +71,7 @@
 		private T SendMessageWithResponse<T>(Message message) where T : Message
 		{
 			var commands = InterAppCallFactory.CreateNew();
+			commands.ReturnAddress = new ReturnAddress(element.AgentId, element.Id, InterAppResponse_ParameterId);
 			commands.Messages.Add(message);
 
 			Log($"Sending message: {JsonConvert.SerializeObject(message)}");


### PR DESCRIPTION
Add the return message when executing the InterAppCall. This is ignored when the message broker is available, but in some cases the message broker isn't available and then it falls back on the return parameter.